### PR TITLE
Update `scripts/` to a latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-bin*
-*.tgz
+/bin
+.DS_Store
+.idea
+/.bin
+/build

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -6,7 +6,8 @@ api = "0.2"
   version = "0.0.12"
 
 [metadata]
-  include_files = ["bin/build","bin/detect","buildpack.toml"]
+  include-files = ["bin/build","bin/detect","buildpack.toml"]
+  pre-package = "./scripts/build.sh"
 
   [metadata.configuration]
     default_bundler_version = "2.1.4"

--- a/package.toml
+++ b/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+uri = "build/buildpack.tgz"

--- a/scripts/.util/git.sh
+++ b/scripts/.util/git.sh
@@ -3,19 +3,19 @@
 set -eu
 set -o pipefail
 
-# shellcheck source=./print.sh
+# shellcheck source=SCRIPTDIR/print.sh
 source "$(dirname "${BASH_SOURCE[0]}")/print.sh"
 
 function util::git::token::fetch() {
-    if [[ -z "${GIT_TOKEN:-""}" ]]; then
-        util::print::title "Fetching GIT_TOKEN"
+  if [[ -z "${GIT_TOKEN:-""}" ]]; then
+    util::print::title "Fetching GIT_TOKEN"
 
-        GIT_TOKEN="$(
-            lpass show Shared-CF\ Buildpacks/concourse-private.yml \
-                | grep buildpacks-github-token \
-                | cut -d ' ' -f 2
-        )"
-    fi
+    GIT_TOKEN="$(
+      lpass show Shared-CF\ Buildpacks/concourse-private.yml \
+        | grep buildpacks-github-token \
+        | cut -d ' ' -f 2
+    )"
+  fi
 
-    printf "%s" "${GIT_TOKEN}"
+  printf "%s" "${GIT_TOKEN}"
 }

--- a/scripts/.util/print.sh
+++ b/scripts/.util/print.sh
@@ -36,7 +36,8 @@ function util::print::success() {
   reset="\033[0;39m"
 
   echo -e "${green}${message}${reset}" >&2
-  exit 0
+  exitcode="${2:-0}"
+  exit "${exitcode}"
 }
 
 function util::print::warn() {

--- a/scripts/.util/tools.sh
+++ b/scripts/.util/tools.sh
@@ -1,135 +1,115 @@
 #!/usr/bin/env bash
+
 set -eu
 set -o pipefail
 
-# shellcheck source=./print.sh
+# shellcheck source=SCRIPTDIR/print.sh
 source "$(dirname "${BASH_SOURCE[0]}")/print.sh"
 
-# shellcheck source=./git.sh
-source "$(dirname "${BASH_SOURCE[0]}")/git.sh"
-
 function util::tools::path::export() {
-    local dir
-    dir="${1}"
+  local dir
+  dir="${1}"
 
-    if ! echo "${PATH}" | grep -q "${dir}"; then
-        PATH="${dir}:$PATH"
-        export PATH
-    fi
-}
-
-function util::tools::pack::install() {
-    local dir version os
-
-    util::print::title "Installing pack"
-
-    while [[ "${#}" != 0 ]]; do
-      case "${1}" in
-        --directory)
-          dir="${2}"
-          shift 2
-          ;;
-
-        --version)
-          version="${2}"
-          shift 2
-          ;;
-
-        *)
-          util::print::error "unknown argument \"${1}\""
-      esac
-    done
-
-    mkdir -p "${dir}"
-    util::tools::path::export "${dir}"
-
-    os="$(uname -s)"
-
-    if [[ "${os}" == "Darwin" ]]; then
-        os="macos"
-    elif [[ "${os}" == "Linux" ]]; then
-        os="linux"
-    else
-        util::print::error "Unsupported operating system"
-    fi
-
-    if [[ ! -f "${dir}/pack" ]]; then
-        util::print::info "--> installing..."
-    elif [[ "$("${dir}/pack" version | cut -d ' ' -f 1)" != *${version}* ]]; then
-        rm "${dir}/pack"
-        util::print::info "--> updating..."
-    else
-        util::print::info "--> skipping..."
-        return 0
-    fi
-
-    GIT_TOKEN="$(util::git::token::fetch)"
-
-    if [[ "${version}" == "latest" ]]; then
-        local url
-        if [[ "${os}" == "macos" ]]; then
-            url="$(
-                curl -s \
-                    -H "Authorization: token ${GIT_TOKEN}" \
-                    https://api.github.com/repos/buildpacks/pack/releases/latest \
-                    | jq --raw-output '.assets[1] | .browser_download_url'
-                )"
-        else
-            url="$(
-                curl -s \
-                    -H "Authorization: token ${GIT_TOKEN}" \
-                    https://api.github.com/repos/buildpacks/pack/releases/latest \
-                    | jq --raw-output '.assets[0] | .browser_download_url'
-                )"
-        fi
-        util::tools::pack::expand "${dir}" "${url}"
-    else
-        local tarball
-        tarball="pack-${version}-${os}.tar.gz"
-        url="https://github.com/buildpacks/pack/releases/download/v${version}/${tarball}"
-        util::tools::pack::expand "${dir}" "${url}"
-    fi
-}
-
-function util::tools::pack::expand() {
-    local dir url version
-    dir="${1}"
-    url="${2}"
-    tarball="$(echo "${url}" | sed "s/.*\///")"
-    version="v$(echo "${url}" | sed 's/pack-//' | sed 's/-.*//')"
-
-    curl --location --silent --output "${tarball}" "${url}"
-    tar xzf "${tarball}" -C "${dir}"
-    rm "${tarball}"
+  if ! echo "${PATH}" | grep -q "${dir}"; then
+    PATH="${dir}:$PATH"
+    export PATH
+  fi
 }
 
 function util::tools::jam::install () {
-    local dir
+  local dir
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --directory)
+        dir="${2}"
+        shift 2
+        ;;
 
-    while [[ "${#}" != 0 ]]; do
-      case "${1}" in
-        --directory)
-          dir="${2}"
-          shift 2
-          ;;
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
 
-        *)
-          util::print::error "unknown argument \"${1}\""
-      esac
-    done
+  local os
+  case "$(uname)" in
+    "Darwin")
+      os="darwin"
+      ;;
 
-    mkdir -p "${dir}"
-    util::tools::path::export "${dir}"
+    "Linux")
+      os="linux"
+      ;;
 
-    if [[ ! -f "${dir}/jam" ]]; then
-        util::print::title "Installing jam"
-        GOBIN="${dir}" go install github.com/cloudfoundry/packit/cargo/jam
-    fi
+    *)
+      echo "Unknown OS \"$(uname)\""
+      exit 1
+  esac
+
+  mkdir -p "${dir}"
+  util::tools::path::export "${dir}"
+
+  if [[ ! -f "${dir}/jam" ]]; then
+    local version
+    version="v0.4.2"
+
+    util::print::title "Installing jam ${version}"
+    curl "https://github.com/paketo-buildpacks/packit/releases/download/${version}/jam-${os}" \
+      --silent \
+      --location \
+      --output "${dir}/jam"
+    chmod +x "${dir}/jam"
+  fi
+}
+
+function util::tools::pack::install() {
+  local dir
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --directory)
+        dir="${2}"
+        shift 2
+        ;;
+
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
+
+  mkdir -p "${dir}"
+  util::tools::path::export "${dir}"
+
+  local os
+  case "$(uname)" in
+    "Darwin")
+      os="macos"
+      ;;
+
+    "Linux")
+      os="linux"
+      ;;
+
+    *)
+      echo "Unknown OS \"$(uname)\""
+      exit 1
+  esac
+
+  if [[ ! -f "${dir}/pack" ]]; then
+    local version
+    version="v0.15.0"
+
+    util::print::title "Installing pack ${version}"
+    curl "https://github.com/buildpacks/pack/releases/download/${version}/pack-${version}-${os}.tgz" \
+      --silent \
+      --location \
+      --output /tmp/pack.tgz
+    tar xzf /tmp/pack.tgz -C "${dir}"
+    chmod +x "${dir}/pack"
+    rm /tmp/pack.tgz
+  fi
 }
 
 function util::tools::packager::install () {
     local dir
-
     while [[ "${#}" != 0 ]]; do
       case "${1}" in
         --directory)
@@ -139,6 +119,8 @@ function util::tools::packager::install () {
 
         *)
           util::print::error "unknown argument \"${1}\""
+          ;;
+
       esac
     done
 
@@ -146,7 +128,17 @@ function util::tools::packager::install () {
     util::tools::path::export "${dir}"
 
     if [[ ! -f "${dir}/packager" ]]; then
-        util::print::title "Installing packager"
-        GOBIN="${dir}" go install github.com/cloudfoundry/libcfbuildpack/packager
+      util::print::title "Installing packager"
+      GOBIN="${dir}" go get -u github.com/cloudfoundry/libcfbuildpack/packager
     fi
+}
+
+function util::tools::tests::checkfocus() {
+  testout="${1}"
+  if grep -q 'Focused: [1-9]' "${testout}"; then
+    echo "Detected Focused Test(s) - setting exit code to 197"
+    rm "${testout}"
+    util::print::success "** GO Test Succeeded **" 197
+  fi
+  rm "${testout}"
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 set -o pipefail
 
@@ -6,21 +7,84 @@ readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly BUILDPACKDIR="$(cd "${PROGDIR}/.." && pwd)"
 
 function main() {
-    local name
-    for src in "${BUILDPACKDIR}"/cmd/*; do
-        name="$(basename "${src}")"
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --help|-h)
+        shift 1
+        usage
+        exit 0
+        ;;
 
-        printf "%s" "Building ${name}..."
+      "")
+        # skip if the argument is empty
+        shift 1
+        ;;
 
-        GOOS="linux" \
-            go build \
-                -mod=vendor \
-                -ldflags="-s -w" \
-                -o "${BUILDPACKDIR}/bin/${name}" \
-                    "${src}/main.go"
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
+
+  mkdir -p "${BUILDPACKDIR}/bin"
+
+  run::build
+  cmd::build
+}
+
+function usage() {
+  cat <<-USAGE
+build.sh [OPTIONS]
+
+Builds the buildpack executables.
+
+OPTIONS
+  --help  -h  prints the command usage
+USAGE
+}
+
+function run::build() {
+  if [[ -f "${BUILDPACKDIR}/run/main.go" ]]; then
+    pushd "${BUILDPACKDIR}/bin" > /dev/null || return
+      printf "%s" "Building run... "
+
+      GOOS=linux \
+        go build \
+          -mod=vendor \
+          -ldflags="-s -w" \
+          -o "run" \
+            "${BUILDPACKDIR}/run"
+
+      echo "Success!"
+
+      for name in detect build; do
+        printf "%s" "Linking ${name}... "
+
+        ln -sf "run" "${name}"
 
         echo "Success!"
+      done
+    popd > /dev/null || return
+  fi
+}
+
+function cmd::build() {
+  if [[ -d "${BUILDPACKDIR}/cmd" ]]; then
+    local name
+    for src in "${BUILDPACKDIR}"/cmd/*; do
+      name="$(basename "${src}")"
+
+      printf "%s" "Building ${name}... "
+
+      GOOS="linux" \
+        go build \
+          -mod=vendor \
+          -ldflags="-s -w" \
+          -o "${BUILDPACKDIR}/bin/${name}" \
+            "${src}/main.go"
+
+      echo "Success!"
     done
+  fi
 }
 
 main "${@:-}"

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -1,77 +1,130 @@
 #!/usr/bin/env bash
+
 set -eu
 set -o pipefail
 
 readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly BUILDPACKDIR="$(cd "${PROGDIR}/.." && pwd)"
 
-# shellcheck source=.util/tools.sh
+# shellcheck source=SCRIPTDIR/.util/tools.sh
 source "${PROGDIR}/.util/tools.sh"
 
-# shellcheck source=.util/print.sh
+# shellcheck source=SCRIPTDIR/.util/print.sh
 source "${PROGDIR}/.util/print.sh"
 
-# shellcheck source=.util/git.sh
+# shellcheck source=SCRIPTDIR/.util/git.sh
 source "${PROGDIR}/.util/git.sh"
 
 function main() {
-    if [[ ! -d "${BUILDPACKDIR}/integration" ]]; then
-        util::print::warn "** WARNING  No Integration tests **"
-    fi
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --use-token|-t)
+        shift 1
+        token::fetch
+        ;;
 
-    tools::install
-    images::pull
-    token::fetch
-    tests::run
+      --help|-h)
+        shift 1
+        usage
+        exit 0
+        ;;
+
+      "")
+        # skip if the argument is empty
+        shift 1
+        ;;
+
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
+
+  if [[ ! -d "${BUILDPACKDIR}/integration" ]]; then
+      util::print::warn "** WARNING  No Integration tests **"
+  fi
+
+  tools::install
+  images::pull
+  tests::run
+}
+
+function usage() {
+  cat <<-USAGE
+integration.sh [OPTIONS]
+
+Runs the integration test suite.
+
+OPTIONS
+  --help       -h  prints the command usage
+  --use-token  -t  use GIT_TOKEN from lastpass
+USAGE
 }
 
 function tools::install() {
-    util::tools::pack::install \
-        --directory "${BUILDPACKDIR}/.bin" \
-        --version "latest"
+  util::tools::pack::install \
+    --directory "${BUILDPACKDIR}/.bin"
 
-    if [[ -f "${BUILDPACKDIR}/.packit" ]]; then
-        util::tools::jam::install \
-            --directory "${BUILDPACKDIR}/.bin"
+  util::tools::jam::install \
+    --directory "${BUILDPACKDIR}/.bin"
 
-    else
-        util::tools::packager::install \
-            --directory "${BUILDPACKDIR}/.bin"
-    fi
+  if [[ ! -f "${BUILDPACKDIR}/.packit" ]]; then
+    util::tools::packager::install \
+      --directory "${BUILDPACKDIR}/.bin"
+  fi
 }
 
 function images::pull() {
-    util::print::title "Pulling build image..."
-    docker pull "${CNB_BUILD_IMAGE:=gcr.io/paketo-buildpacks/build:full-cnb-cf}"
+  local builder
+  builder=""
 
-    util::print::title "Pulling run image..."
-    docker pull "${CNB_RUN_IMAGE:=gcr.io/paketo-buildpacks/run:full-cnb-cf}"
+  if [[ -f "${BUILDPACKDIR}/integration.json" ]]; then
+    builder="$(jq -r .builder "${BUILDPACKDIR}/integration.json")"
+  fi
 
-    util::print::title "Pulling cflinuxfs3 builder image..."
-    docker pull "${CNB_BUILDER_IMAGE:=gcr.io/paketo-buildpacks/builder:cflinuxfs3}"
+  if [[ "${builder}" == "null" || -z "${builder}" ]]; then
+    builder="index.docker.io/paketobuildpacks/builder:base"
+  fi
 
-    export CNB_BUILD_IMAGE
-    export CNB_RUN_IMAGE
-    export CNB_BUILDER_IMAGE
+  util::print::title "Pulling builder image..."
+  docker pull "${builder}"
 
-    util::print::title "Setting default pack builder image..."
-    pack set-default-builder "${CNB_BUILDER_IMAGE}"
+  util::print::title "Setting default pack builder image..."
+  pack set-default-builder "${builder}"
+
+  local run_image lifecycle_image
+  run_image="$(
+    pack inspect-builder "${builder}" --output json \
+      | jq -r '.remote_info.run_images[0].name'
+  )"
+  lifecycle_image="index.docker.io/buildpacksio/lifecycle:$(
+    pack inspect-builder "${builder}" --output json \
+      | jq -r '.remote_info.lifecycle.version'
+  )"
+
+  util::print::title "Pulling run image..."
+  docker pull "${run_image}"
+
+  util::print::title "Pulling lifecycle image..."
+  docker pull "${lifecycle_image}"
 }
 
 function token::fetch() {
-    GIT_TOKEN="$(util::git::token::fetch)"
-    export GIT_TOKEN
+  GIT_TOKEN="$(util::git::token::fetch)"
+  export GIT_TOKEN
 }
 
 function tests::run() {
-    util::print::title "Run Buildpack Runtime Integration Tests"
-    pushd "${BUILDPACKDIR}" > /dev/null
-        if GOMAXPROCS=4 go test -timeout 0 ./integration/... -v -mod=vendor -run Integration; then
-            util::print::success "** GO Test Succeeded **"
-        else
-            util::print::error "** GO Test Failed **"
-        fi
-    popd > /dev/null
+  util::print::title "Run Buildpack Runtime Integration Tests"
+
+  testout=$(mktemp)
+  pushd "${BUILDPACKDIR}" > /dev/null
+    if GOMAXPROCS="${GOMAXPROCS:-4}" go test -count=1 -timeout 0 ./integration/... -v -run Integration | tee "${testout}"; then
+      util::tools::tests::checkfocus "${testout}"
+      util::print::success "** GO Test Succeeded **"
+    else
+      util::print::error "** GO Test Failed **"
+    fi
+  popd > /dev/null
 }
 
 main "${@:-}"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,114 +1,124 @@
 #!/usr/bin/env bash
+
 set -eu
 set -o pipefail
 
-readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly BUILDPACKDIR="$(cd "${PROGDIR}/.." && pwd)"
+readonly ROOT_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
+readonly BIN_DIR="${ROOT_DIR}/.bin"
+readonly BUILD_DIR="${ROOT_DIR}/build"
 
-# shellcheck source=.util/tools.sh
-source "${PWD}/scripts/.util/tools.sh"
+# shellcheck source=SCRIPTDIR/.util/tools.sh
+source "${ROOT_DIR}/scripts/.util/tools.sh"
 
-# shellcheck source=.util/print.sh
-source "${PWD}/scripts/.util/print.sh"
+# shellcheck source=SCRIPTDIR/.util/print.sh
+source "${ROOT_DIR}/scripts/.util/print.sh"
 
-if ! command -v realpath > /dev/null; then
-  function realpath() {
-      [[ "${1}" = /* ]] && echo "${1}" || echo "${PWD}/${1#./}"
-  }
-fi
+function main {
+  local version output
 
-function main() {
-    local full_path args version cached archive offline
-    PACKAGE_DIR=${PACKAGE_DIR:-"${BUILDPACKDIR}/$(basename ${BUILDPACKDIR})_$(openssl rand -hex 4)"}
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --version|-v)
+        version="${2}"
+        shift 2
+        ;;
 
-    full_path="$(realpath "${PACKAGE_DIR}")"
+      --output|-o)
+        output="${2}"
+        shift 2
+        ;;
 
-    while [[ "${#}" != 0 ]]; do
-      case "${1}" in
-        --archive|-a)
-          archive="true"
-          shift 1
-          ;;
+      --help|-h)
+        shift 1
+        usage
+        exit 0
+        ;;
 
-        --cached|-c)
-          cached="true"
-          offline="true"
-          shift 1
-          ;;
+      "")
+        # skip if the argument is empty
+        shift 1
+        ;;
 
-        --version|-v)
-          version="${2}"
-          shift 2
-          ;;
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
 
-        "")
-          # skip if the argument is empty
-          shift 1
-          ;;
+  if [[ -z "${version:-}" ]]; then
+    usage
+    echo
+    util::print::error "--version is required"
+  fi
 
-        *)
-          util::print::error "unknown argument \"${1}\""
-      esac
-    done
+  if [[ -z "${output:-}" ]]; then
+    output="${BUILD_DIR}/buildpackage.cnb"
+  fi
 
-    if [[ -f "${BUILDPACKDIR}/.packit" ]]; then
-        #use jam
-        util::tools::jam::install --directory "${BUILDPACKDIR}/.bin"
-        if [[ -z "${version:-}" ]]; then #version not provided, use latest git tag
-            git_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-            version=${git_tag:1}
-        fi
+  repo::prepare
+  buildpack::archive "${version}"
+  buildpackage::create "${output}"
+}
 
-        extra_args=""
+function usage() {
+  cat <<-USAGE
+package.sh --version <version> [OPTIONS]
 
-        if [[ -n "${offline:-}" ]]; then
-            PACKAGE_DIR="${PACKAGE_DIR}-cached"
-            extra_args+="--offline"
-        fi
+Packages the buildpack into a buildpackage .cnb file.
 
-        if [[ "${PACKAGE_DIR}" != "*.tgz" ]]; then
-            PACKAGE_DIR="${PACKAGE_DIR}.tgz"
-        fi
+OPTIONS
+  --help               -h            prints the command usage
+  --version <version>  -v <version>  specifies the version number to use when packaging the buildpack
+  --output <output>    -o <output>   location to output the packaged buildpackage artifact (default: ${ROOT_DIR}/build/buildpackage.cnb)
+USAGE
+}
 
+function repo::prepare() {
+  util::print::title "Preparing repo..."
 
-        .bin/jam pack \
-        --buildpack "$(pwd)/buildpack.toml" \
-        --version "${version}" \
-        --output "${PACKAGE_DIR}" \
-        ${extra_args}
+  rm -rf "${BUILD_DIR}"
 
-    else
-        # use old packager
-        util::tools::packager::install --directory "${BUILDPACKDIR}/.bin"
+  mkdir -p "${BIN_DIR}"
+  mkdir -p "${BUILD_DIR}"
 
-        args="${BUILDPACKDIR}/.bin/packager"
-        if [[ -n "${cached:-}" ]]; then
-            full_path="${full_path}-cached"
-        else
-            args="${args} --uncached"
-        fi
+  export PATH="${BIN_DIR}:${PATH}"
+}
 
-        if [[ -n "${archive:-}" ]]; then
-            args="${args} -archive"
-        fi
+function buildpack::archive() {
+  local version
+  version="${1}"
 
-        if [[ -z "${version:-}" ]]; then
-            version="$(cd "${BUILDPACKDIR}" && git describe --tags `git rev-list --tags --max-count=1`)"
-        fi
+  util::print::title "Packaging buildpack into ${BUILD_DIR}/buildpack.tgz..."
 
-        args="${args} -version ${version}"
+  if [[ -f "${ROOT_DIR}/.packit" ]]; then
+    util::tools::jam::install --directory "${BIN_DIR}"
 
-        pushd "${BUILDPACKDIR}" > /dev/null
-            eval "${args}" "${full_path}"
-        popd > /dev/null
+    jam pack \
+      --buildpack "${ROOT_DIR}/buildpack.toml" \
+      --version "${version}" \
+      --output "${BUILD_DIR}/buildpack.tgz"
+  else
+    util::tools::packager::install --directory "${BIN_DIR}"
 
-        if [[ -n "${BP_REWRITE_HOST:-}" ]]; then
-            sed -i '' -e "s|^uri = \"https:\/\/buildpacks\.cloudfoundry\.org\(.*\)\"$|uri = \"http://${BP_REWRITE_HOST}\1\"|g" "${full_path}/buildpack.toml"
-        fi
-    fi
+    packager \
+      --uncached \
+      --archive \
+      --version "${version}" \
+      "${BUILD_DIR}/buildpack"
+  fi
+}
 
+function buildpackage::create() {
+  local output
+  output="${1}"
 
+  util::print::title "Packaging buildpack..."
 
+  util::tools::pack::install --directory "${BIN_DIR}"
+
+  pack \
+    package-buildpack "${output}" \
+      --config "${ROOT_DIR}/package.toml" \
+      --format file
 }
 
 main "${@:-}"

--- a/scripts/unit.sh
+++ b/scripts/unit.sh
@@ -1,23 +1,62 @@
 #!/usr/bin/env bash
+
 set -eu
 set -o pipefail
 
 readonly PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly BUILDPACKDIR="$(cd "${PROGDIR}/.." && pwd)"
 
-# shellcheck source=.util/print.sh
+# shellcheck source=SCRIPTDIR/.util/tools.sh
+source "${PROGDIR}/.util/tools.sh"
+
+# shellcheck source=SCRIPTDIR/.util/print.sh
 source "${PROGDIR}/.util/print.sh"
 
 function main() {
-    util::print::title "Run Buildpack Unit Tests"
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --help|-h)
+        shift 1
+        usage
+        exit 0
+        ;;
 
-    pushd "${BUILDPACKDIR}" > /dev/null
-        if go test -mod=vendor ./... -v -run Unit; then
-            util::print::success "** GO Test Succeeded **"
-        else
-            util::print::error "** GO Test Failed **"
-        fi
-    popd > /dev/null
+      "")
+        # skip if the argument is empty
+        shift 1
+        ;;
+
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
+
+  unit::run
+}
+
+function usage() {
+  cat <<-USAGE
+unit.sh [OPTIONS]
+
+Runs the unit test suite.
+
+OPTIONS
+  --help  -h  prints the command usage
+USAGE
+}
+
+function unit::run() {
+  util::print::title "Run Buildpack Unit Tests"
+
+  testout=$(mktemp)
+  pushd "${BUILDPACKDIR}" > /dev/null
+    if go test -mod=vendor ./... -v -run Unit | tee "${testout}"; then
+      util::tools::tests::checkfocus "${testout}"
+      util::print::success "** GO Test Succeeded **"
+    else
+      util::print::error "** GO Test Failed **"
+    fi
+  popd > /dev/null
 }
 
 main "${@:-}"


### PR DESCRIPTION
Update `scripts/` to a latest version
from github.com/paketo-buildpacks/github-config.

Create `package.toml` file as a new requirement.
Update `buildpack.toml` to new API requirements.

Create `.packit` file as a part of updating `scripts/`
Update `.gitignore` to skip all directories with binaries.